### PR TITLE
Vertex arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.o
+Makefile
+moc_*
+ui_*
+GCodeViewer

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Makefile
 moc_*
 ui_*
 GCodeViewer
+*.pro.user

--- a/gcode.cpp
+++ b/gcode.cpp
@@ -251,4 +251,46 @@ void gcodeModel::loadGCode(QString filename) {
         }
 
     }
+
+    refreshVertexes(0);
+}
+
+void gcodeModel::refreshVertexes(int currentLayer) {
+    vertexes.resize(points.size());
+
+    for(unsigned int i = 0; i < points.size(); i++) {
+        const point& pt = points[i];
+        GLVertex& vert = vertexes[i];
+
+        // set position
+        vert.x = pt.x;
+        vert.y = pt.y;
+        vert.z = pt.z;
+        vert.w = 0;
+
+        // base alpha on current layer
+        float alpha = .02;
+        if (map.heightLessThanLayer(currentLayer, pt.z)) {
+            alpha = .20;
+        }
+        else if (map.heightInLayer(currentLayer, pt.z)) {
+            alpha = 1;
+        }
+
+        // scale the feedrate to the bounds of what this job contains;
+        float val = (pt.flowrate - flowrateBounds.getMin())/(flowrateBounds.getMax() - flowrateBounds.getMin());
+
+        // set color
+        vert.r = val;
+        vert.g = 1-val;
+        vert.b = 0;
+        vert.a = alpha;
+
+        if (!pt.toolEnabled) {
+            vert.r = 0;
+            vert.g = 0;
+            vert.b = 255;
+            vert.a = alpha;
+        }
+    }
 }

--- a/gcode.h
+++ b/gcode.h
@@ -132,6 +132,12 @@ public:
 };
 
 
+struct GLVertex
+{
+    float x, y, z, w;
+    float r, g, b, a;
+};
+
 
 // Object that can open a file containing GCode and turn it into a series of lines
 class gcodeModel {
@@ -143,12 +149,16 @@ public:
     minMax<float> flowrateBounds;
     minMax<float> zHeightBounds;
 
+    vector< GLVertex > vertexes;
+
 public:
     gcodeModel();
 
     void loadGCode(QString filename);
     void exportGCode(QString filename);
     float getModelZCenter();
+
+    void refreshVertexes(int currentLayer);
 };
 
 

--- a/gcodeview.cpp
+++ b/gcodeview.cpp
@@ -101,44 +101,19 @@ void GcodeView::paintGL()
 
     mat4 tmp_rot = arcball.rot;
     glMultMatrixf( (float*) &tmp_rot[0][0] );
-    glTranslatef(0.0f, 0.0f,  -model.getModelZCenter());
+    glTranslatef(0.0f, 0.0f, -model.getModelZCenter());
 
     glLineWidth(2);
-    glBegin(GL_LINE_STRIP);
 
+    glEnableClientState(GL_VERTEX_ARRAY);
+    glEnableClientState(GL_COLOR_ARRAY);
 
-    for (unsigned int i = 1; i < model.points.size(); i++) {
-            point a = model.points[i-1];
-            point b = model.points[i];
+    glVertexPointer(3, GL_FLOAT, sizeof(GLVertex), &model.vertexes[0].x);
+    glColorPointer(4, GL_FLOAT, sizeof(GLVertex), &model.vertexes[0].r);
+    glDrawArrays(GL_LINE_STRIP, 0, model.vertexes.size());
 
-            float alpha = 0;
-
-            if (model.map.heightLessThanLayer(currentLayer, b.z)) {
-                alpha = .20;
-            }
-            else if (model.map.heightInLayer(currentLayer, b.z)) {
-                alpha = 1;
-            }
-            else {
-                alpha = .02;
-            }
-
-
-            // scale the feedrate to the bounds of what this job contains;
-//            float val = (b.feedrate - model.feedrateBounds.getMin())/(model.feedrateBounds.getMax() - model.feedrateBounds.getMin());
-            float val = (b.flowrate - model.flowrateBounds.getMin())/(model.flowrateBounds.getMax() - model.flowrateBounds.getMin());
-
-            glColor4f(val,1-val,0,alpha);
-
-            if (!b.toolEnabled) {
-                glColor4f(0,0,255,alpha);
-            }
-
-            glVertex3f(a.x, a.y, a.z); // origin of the line
-            glVertex3f(b.x, b.y, b.z); // ending point of the line
-    }
-
-    glEnd( );
+    glDisableClientState(GL_VERTEX_ARRAY);
+    glDisableClientState(GL_COLOR_ARRAY);
 
     glPopMatrix();
 }
@@ -216,6 +191,7 @@ void GcodeView::setCurrentLayer(int layer) {
     if (layer < model.map.size()) {
         currentLayer = layer;
         std::cout << "Current layer: " << layer << ", height: " << model.map.getLayerHeight(layer) << std::endl;
+        model.refreshVertexes(currentLayer);
         updateGL();
     }
 }

--- a/gcodeviewapplication.cpp
+++ b/gcodeviewapplication.cpp
@@ -1,7 +1,7 @@
 #include "gcodeviewapplication.h"
 #include "mainwindow.h"
 
-GCodeViewApplication::GCodeViewApplication(int argc, char *argv[]) :
+GCodeViewApplication::GCodeViewApplication(int& argc, char *argv[]) :
     QApplication(argc, argv)
 {
     setOrganizationName("MakerBot Industries");

--- a/gcodeviewapplication.h
+++ b/gcodeviewapplication.h
@@ -6,7 +6,7 @@
 class GCodeViewApplication : public QApplication
 {
 public:
-    GCodeViewApplication(int argc, char *argv[]);
+    GCodeViewApplication(int& argc, char *argv[]);
 
     // Load a file into the correct place (a new window if it's not already open, etc)
     static void LoadFile(QString fileName);


### PR DESCRIPTION
Vertex arrays should render much faster on larger gcode files since they cut way, way down on the number of OpenGL API calls needed per draw operation.
